### PR TITLE
Add local file URL to callback response

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ let url = '/path/to/remote/file'
 let folderPath = RNFS.DocumentDirectoryPath
 
 FileDownload.download(url, folderPath)
-.then(() => {
-  console.log('downloaded!')
+.then((response) => {
+  console.log('downloaded! file saved to: ' + response)
 })
 .catch((error) => {
   console.log(error)

--- a/RNFileDownload.m
+++ b/RNFileDownload.m
@@ -26,7 +26,7 @@ RCT_EXPORT_METHOD(download:(NSString *)source targetPath:(NSString *)targetPath 
                                                       [[NSFileManager defaultManager] moveItemAtURL:location
                                                                                               toURL:targetURL
                                                                                               error:nil];
-                                                      callback(@[[NSNull null]]);
+                                                      callback(@[[NSNull null], targetURL.absoluteString]);
                                                   } else {
                                                       NSLog(@"%@", [error description]);
                                                       callback(@[[error description]]);


### PR DESCRIPTION
Grants access to the file directly after saving. Prior promise response was empty.
